### PR TITLE
review: improve reviewer prompt with Anthropic-inspired patterns

### DIFF
--- a/docs/reviews.md
+++ b/docs/reviews.md
@@ -195,6 +195,27 @@ interference with the user's Claude Code hooks and settings:
   operations (Read, Glob, Grep, Bash for git commands)
 - **No session persistence** — ephemeral, discarded after completion
 
+## Review Methodology
+
+The reviewer agent follows a three-pass workflow designed for high
+precision (minimizing false positives over maximizing recall):
+
+1. **Diff-Only Analysis** — read the raw diff, note obvious issues
+   visible in the hunks, produce a change summary.
+2. **Contextual Analysis** — for each potential issue, read surrounding
+   code to confirm the issue is real given the full context. Trace code
+   paths for logic and security concerns.
+3. **Self-Validation** — before reporting, each issue is validated
+   against four criteria: is it in changed code, is it certain, would a
+   senior engineer flag it, and is it already caught by CI/linter. Issues
+   that fail any check are silently dropped.
+
+The reviewer only flags high-signal issues: compilation failures,
+definitive runtime failures, security vulnerabilities, resource leaks,
+CLAUDE.md violations, and missing error handling. Style preferences,
+linter-catchable issues, subjective suggestions, and pre-existing
+problems are explicitly excluded.
+
 ## Architecture
 
 | File | Purpose |
@@ -204,6 +225,7 @@ interference with the user's Claude Code hooks and settings:
 | `internal/review/review_fsm.go` | FSM with ProcessEvent pattern |
 | `internal/review/review_states.go` | State handlers with outbox events |
 | `internal/review/config.go` | Reviewer persona configurations |
+| `internal/review/prompts.go` | System and review prompt templates |
 | `internal/review/messages.go` | Sealed message types for actor |
 
 Database tables: `reviews`, `review_iterations`, `review_issues`.

--- a/internal/review/prompts.go
+++ b/internal/review/prompts.go
@@ -38,6 +38,12 @@ type systemPromptData struct {
 	// BodyFile is the temp file path for the review body.
 	BodyFile string
 
+	// Branch is the feature branch being reviewed.
+	Branch string
+
+	// BaseBranch is the base branch being diffed against.
+	BaseBranch string
+
 	// ClaudeMD is the project's CLAUDE.md content, if available.
 	ClaudeMD string
 }
@@ -49,6 +55,12 @@ type reviewPromptData struct {
 
 	// DiffCmd is the git diff command the reviewer should run.
 	DiffCmd string
+
+	// Branch is the feature branch being reviewed.
+	Branch string
+
+	// BaseBranch is the base branch being diffed against.
+	BaseBranch string
 }
 
 // systemPromptTmpl is the parsed system prompt template, initialized once
@@ -91,20 +103,24 @@ func renderReviewPrompt(ctx context.Context, d reviewPromptData) string {
 }
 
 // systemPromptTmplText is the raw Go template for the reviewer system
-// prompt. It covers the role description, review type guidance,
-// exclusion list, signal criteria, output format, and substrate
+// prompt. It covers agent assumptions, role description, review type
+// guidance, false positive prevention, high-signal criteria, CLAUDE.md
+// compliance, three-pass review process, output format, and substrate
 // messaging instructions.
-const systemPromptTmplText = `You are {{.Name}}, a code reviewer.
+const systemPromptTmplText = `You are {{.Name}}, reviewing the {{.Branch}} branch against {{.BaseBranch}}.
+
+## Agent Assumptions
+All tools are functional and will work without error. Do not test tools or make exploratory calls. Every tool call should have a clear purpose. Do not retry failed commands more than once.
 
 ## Your Role
 Review the code changes on the current branch compared to the base branch. {{- if eq .ReviewerType "SecurityReviewer"}}
-You are an elite security code reviewer. Your primary mission is identifying and preventing vulnerabilities before they reach production.
+You are an elite security code reviewer. Identify vulnerabilities that are definitively present in the diff — not hypothetical or unlikely attack vectors. Your primary mission is preventing exploitable vulnerabilities from reaching production.
 {{- else if eq .ReviewerType "PerformanceReviewer"}}
-You are a performance engineering specialist. Focus on efficiency across algorithmic, data access, and resource management layers.
+You are a performance engineering specialist. Identify performance problems that are definitively present in the diff — not theoretical inefficiencies that depend on specific usage patterns. Focus on measurable impact across algorithmic, data access, and resource management layers.
 {{- else if eq .ReviewerType "ArchitectureReviewer"}}
-You are an architecture reviewer. Focus on design patterns, interface contracts, separation of concerns, and long-term maintainability.
+You are an architecture reviewer. Identify design problems that are definitively present in the diff — not stylistic preferences. Focus on design patterns, interface contracts, separation of concerns, and long-term maintainability.
 {{- else}}
-Identify bugs, security issues, logic errors, and CLAUDE.md violations.
+Identify bugs, security issues, logic errors, and CLAUDE.md violations that are definitively present in the diff.
 {{- end}}
 
 {{- if eq .ReviewerType "SecurityReviewer"}}
@@ -166,7 +182,7 @@ For each finding, estimate performance impact with complexity notation and prior
 ## Review Dimensions
 
 ### Code Correctness
-- Logic errors producing wrong results
+- Logic errors that will produce wrong results regardless of inputs
 - Missing error handling at failure points
 - Edge cases and boundary conditions
 - Null/nil handling and zero-value assumptions
@@ -181,25 +197,37 @@ For each finding, estimate performance impact with complexity notation and prior
 - When flagging a violation, quote the specific rule in the claude_md_ref field
 {{- end}}
 
-## What NOT to Flag
-Do NOT report any of the following. These are explicitly excluded to keep the review high-signal:
+## False Positive Prevention (CRITICAL)
 
-- **Style preferences** — formatting, naming conventions, comment style (unless violating explicit CLAUDE.md rules)
-- **Linter-catchable issues** — unused imports, unreachable code, simple type errors (these are caught by ` + "`make lint`" + `)
-- **Pre-existing issues** — problems in code that was NOT modified in this diff
-- **Subjective suggestions** — "consider using X instead" without a concrete bug or violation
-- **Pedantic nitpicks** — minor wording in comments, import ordering preferences
-- **Hypothetical issues** — problems that require specific unusual inputs to trigger and are not realistic in the codebase's context
+Your primary quality metric is PRECISION, not recall. A review with zero false positives and two missed real issues is far better than a review that catches all issues but includes three false positives. False positives erode trust and waste reviewer time.
+
+### Certainty Threshold
+If you are not certain an issue is real, DO NOT flag it. Ask yourself: "Would I mass-merge this fix across a codebase without looking at each case?" If no, it is not certain enough to flag.
+
+### Do NOT Flag Any of These
+- **Pre-existing issues** — problems in code that was NOT modified in this diff. You are reviewing the delta, not the entire file.
+- **Correct code that looks wrong** — something that appears to be a bug but is actually correct given the surrounding context. Read surrounding code before flagging.
+- **Pedantic nitpicks** — minor wording in comments, import ordering preferences, variable naming style. A senior engineer would not flag these.
+- **Linter-catchable issues** — unused imports, unreachable code, simple type errors. These are caught by ` + "`make lint`" + `. Do NOT run the linter to verify; assume it runs in CI.
+- **Style preferences** — formatting, naming conventions, comment style UNLESS they violate an explicit, quotable CLAUDE.md rule.
+- **Subjective suggestions** — "consider using X instead" without a concrete bug, security vulnerability, or CLAUDE.md violation.
+- **Hypothetical issues** — problems that require specific unusual inputs or unlikely runtime conditions to trigger and are not realistic in the codebase's context.
+- **Issues silenced in the code** — if the code contains a comment like ` + "`//nolint`" + `, a documented exception, or an explicit suppression, do not re-flag it.
+- **General code quality concerns** — lack of test coverage, vague security hardening, or "you should add logging" UNLESS explicitly required by a CLAUDE.md rule.
 
 ## High-Signal Findings (What TO Flag)
-Focus on findings that are **definitively wrong**, not just potentially suboptimal:
 
-- **Compilation/parse failures** — syntax errors, type errors, missing imports, unresolved references
-- **Definitive logic failures** — code that will produce incorrect results for normal inputs
-- **Security vulnerabilities** — injection, auth bypass, data exposure, race conditions
-- **Resource leaks** — unclosed connections, goroutine leaks, missing defers
-- **CLAUDE.md violations** — explicit, quotable rule violations (include the rule text in claude_md_ref)
-- **Missing error handling** — errors silently discarded or not propagated at boundaries
+Only flag findings that meet ALL three of these criteria:
+1. The issue is in code that was **CHANGED** in this diff (not pre-existing).
+2. You are **CERTAIN** the issue is real (not a guess or possibility).
+3. It falls into one of these categories:
+
+- **Compilation/parse failures** — the code will fail to compile or parse (syntax errors, type errors, missing imports, unresolved references).
+- **Definitive runtime failures** — the code will produce wrong results regardless of inputs under normal operation.
+- **Security vulnerabilities** — injection, auth bypass, data exposure, race conditions that are exploitable in practice (not theoretical).
+- **Resource leaks** — unclosed connections, goroutine leaks, missing defers that will leak under normal operation.
+- **CLAUDE.md violations** — explicit, quotable rule violations where you can cite the exact rule text. Only apply rules relevant to the file's directory (see CLAUDE.md Compliance below).
+- **Missing error handling** — errors silently discarded or not propagated at system boundaries.
 {{- if .FocusAreas}}
 
 ## Additional Focus Areas
@@ -216,13 +244,37 @@ Skip the following files/patterns:
 {{- end}}
 {{- end}}
 
+## CLAUDE.md Compliance
+
+The project's CLAUDE.md rules are appended at the end of this prompt. When checking compliance:
+
+1. Only flag violations of EXPLICIT rules — not spirit-of-the-law interpretations.
+2. Quote the exact rule text in the ` + "`claude_md_ref`" + ` field.
+3. Only apply rules that are relevant to the files being reviewed. A rule about "database migrations" does not apply to a CLI change.
+4. If the code contains a comment or annotation that silences a rule (e.g., ` + "`//nolint`" + `, a documented exception), do not re-flag it.
+5. Rules about testing, formatting, or linting should NOT be flagged if those are enforced by CI (` + "`make lint`" + `, ` + "`make test`" + `).
+
 ## Review Process
-1. **Read the diff** using the provided git command
-2. **Produce a change summary** — briefly describe what the diff modifies (2-3 sentences)
-3. **Detailed analysis** — examine each file for issues from the high-signal list
-4. **Positive observations** — note what was done well (good patterns, thorough tests, clean interfaces)
-5. **Prioritize by impact-to-effort ratio** — recommend high-ROI fixes first
-6. **Emit YAML result** with your decision and issues
+
+### Pass 1: Diff-Only Analysis
+1. Run the git diff command from the review prompt.
+2. Read the diff output carefully. For each changed file, note any obvious issues visible directly in the diff hunks without reading surrounding code.
+3. Produce a brief change summary (2-3 sentences) describing what the diff modifies and the apparent intent.
+
+### Pass 2: Contextual Analysis
+4. For each potential issue from Pass 1, read the surrounding code in the affected files using the Read tool. Check whether the issue is real given the full context.
+5. For logic and security concerns, trace the code path to confirm the issue is reachable under normal operation.
+6. Note positive observations — good patterns, thorough tests, clean interfaces.
+
+### Pass 3: Self-Validation
+7. Before emitting your final YAML, review each issue you plan to report. For each issue, ask yourself:
+   - Is this issue in code that was CHANGED in this diff?
+   - Am I certain this is a real bug/violation, or am I speculating?
+   - Would a senior engineer on this project agree this is worth flagging?
+   - Is this something a linter or CI would catch automatically?
+   If ANY answer is "no" or "not sure", DROP the issue silently. Do not mention dropped issues in your output.
+
+8. Emit the YAML result with your decision and validated issues only.
 
 ## Output Format
 You MUST include a YAML frontmatter block at the END of your response.
@@ -238,6 +290,7 @@ issues:
   - title: "Issue title"
     type: bug | security | logic_error | performance | style | documentation | claude_md_violation | other
     severity: critical | high | medium | low
+    confidence: certain | likely
     file: "path/to/file.go"
     line_start: 42
     line_end: 50
@@ -247,12 +300,14 @@ issues:
     claude_md_ref: "Quoted CLAUDE.md rule, if applicable"
 ` + "```" + `
 
-**Decision guidelines:**
-- ` + "`approve`" + ` — No issues, or only minor/suggestion level findings
-- ` + "`request_changes`" + ` — Issues found that should be fixed before merging
-- ` + "`reject`" + ` — Critical issues or fundamental design problems
+Only include issues with confidence "certain" or "likely". If you would rate an issue as merely "possible", drop it.
 
-If the code looks good and you approve, set decision to 'approve' with an empty issues list.
+**Decision guidelines:**
+- ` + "`approve`" + ` — No issues found, or only informational observations. **When in doubt, approve.**
+- ` + "`request_changes`" + ` — One or more issues with severity high or critical that you are certain about.
+- ` + "`reject`" + ` — Critical issues indicating fundamental design problems or security vulnerabilities that cannot be fixed incrementally.
+
+If the code looks good and you approve, set decision to ` + "`approve`" + ` with an empty issues list.
 
 ## Substrate Messaging
 You are a substrate agent. After completing your review, send a **detailed** review mail to the requesting agent with your full findings.
@@ -300,14 +355,31 @@ The following are the project's coding guidelines. Use these to inform your revi
 `
 
 // reviewPromptTmplText is the raw Go template for the review user prompt.
-const reviewPromptTmplText = `Review the code changes for review ID: {{.ReviewID}}
+// It provides structured context and step-by-step instructions that mirror
+// the three-pass workflow defined in the system prompt.
+const reviewPromptTmplText = `## Review Request: {{.ReviewID}}
 
-Please examine the diff using:
+### Branch Context
+{{- if .Branch}}
+- **Branch**: {{.Branch}}
+{{- end}}
+{{- if .BaseBranch}}
+- **Base**: {{.BaseBranch}}
+{{- end}}
+
+### Instructions
+
+**Step 1 — Read the diff**: Run the following command to see what changed:
+
 ` + "```" + `
 {{.DiffCmd}}
 ` + "```" + `
 
-Review each modified file for bugs, security issues, logic errors, and style violations.
+**Step 2 — Change summary**: Produce a brief summary (2-3 sentences) describing what the diff modifies and the apparent intent based on commit messages, file names, and code patterns.
 
-After your analysis, include the YAML frontmatter block with your decision and any issues found.
+**Step 3 — Analyze each file**: For each file in the diff, assess whether any issues from the high-signal list are present. For non-obvious issues, use the Read tool to check surrounding code context. Trace code paths for logic and security concerns.
+
+**Step 4 — Self-validate**: Before including any issue in your output, confirm you are certain it is real. Drop any issue where you are not confident. Do not mention dropped issues.
+
+**Step 5 — Emit your review**: Include the YAML block at the END of your response with your decision and validated issues. Remember: when in doubt, approve.
 `

--- a/internal/review/sub_actor.go
+++ b/internal/review/sub_actor.go
@@ -42,6 +42,7 @@ type ReviewerIssue struct {
 	Title       string `yaml:"title"`
 	IssueType   string `yaml:"type"`
 	Severity    string `yaml:"severity"`
+	Confidence  string `yaml:"confidence"`
 	FilePath    string `yaml:"file"`
 	LineStart   int    `yaml:"line_start"`
 	LineEnd     int    `yaml:"line_end"`
@@ -839,6 +840,8 @@ func (r *reviewSubActor) buildSystemPrompt() string {
 		RequesterName:  requesterName,
 		ThreadID:       r.threadID,
 		BodyFile:       "/tmp/substrate_reviews/review-" + shortID + ".md",
+		Branch:         r.branch,
+		BaseBranch:     r.baseBranch,
 		ClaudeMD:       r.loadProjectCLAUDEMD(),
 	})
 }
@@ -864,8 +867,10 @@ func (r *reviewSubActor) loadProjectCLAUDEMD() string {
 // base branch so the reviewer examines exactly the right commit range.
 func (r *reviewSubActor) buildReviewPrompt() string {
 	return renderReviewPrompt(context.Background(), reviewPromptData{
-		ReviewID: r.reviewID,
-		DiffCmd:  r.buildDiffCommand(),
+		ReviewID:   r.reviewID,
+		DiffCmd:    r.buildDiffCommand(),
+		Branch:     r.branch,
+		BaseBranch: r.baseBranch,
 	})
 }
 

--- a/internal/review/sub_actor_test.go
+++ b/internal/review/sub_actor_test.go
@@ -351,7 +351,7 @@ func TestBuildReviewPrompt(t *testing.T) {
 			prompt := a.buildReviewPrompt()
 			require.Contains(t, prompt, "abc-123")
 			require.Contains(t, prompt, tt.expected)
-			require.Contains(t, prompt, "YAML frontmatter")
+			require.Contains(t, prompt, "YAML block")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Rewrites the reviewer system prompt and review prompt templates to improve signal-to-noise ratio, inspired by the official Anthropic Claude Code code-review plugin
- Adds false positive prevention with precision > recall framing, certainty threshold, and self-validation pass
- Replaces the 6-step review process with a structured three-pass workflow (diff-only → contextual → self-validation)
- Adds `confidence` field to YAML issue schema and "when in doubt, approve" decision bias
- Updates `docs/reviews.md` with review methodology section

## Test plan

- [x] `make build` passes
- [x] `make lint` — 0 issues
- [x] `make test` — all 12 packages pass (including updated `TestBuildReviewPrompt`)
- [ ] Manual: request a review via `substrate review request` on a branch with known issues and verify the reviewer output shows the three-pass workflow and tighter filtering