### PR TITLE
web: add fullscreen toggle, drag-to-resize, and markdown rendering fixes

### DIFF
--- a/internal/review/messages.go
+++ b/internal/review/messages.go
@@ -79,18 +79,18 @@ func (ResumeReviewMsg) MessageType() string { return "ResumeReviewMsg" }
 type CreateReviewMsg struct {
 	actor.BaseMessage
 
-	RequesterID int64
-	PRNumber    int
-	Branch      string
-	BaseBranch  string
-	CommitSHA   string
-	RepoPath    string
-	RemoteURL   string
+	RequesterID   int64
+	PRNumber      int
+	Branch        string
+	BaseBranch    string
+	CommitSHA     string
+	RepoPath      string
+	RemoteURL     string
 	ReviewType    string // full, incremental, security, performance.
 	SecurityDepth string // standard, deep, full (defaults based on ReviewType).
 	Priority      string // urgent, normal, low.
-	Reviewers   []string
-	Description string
+	Reviewers     []string
+	Description   string
 }
 
 // MessageType implements actor.Message.

--- a/internal/review/sub_actor.go
+++ b/internal/review/sub_actor.go
@@ -85,12 +85,12 @@ func DefaultSubActorSpawnConfig() *SpawnConfig {
 // goroutine per review, creates a Claude Agent SDK client, sends the review
 // prompt, processes the response, and feeds events back to the service.
 type reviewSubActor struct {
-	reviewID   string
-	threadID   string
-	repoPath   string
-	requester  int64
-	branch     string
-	baseBranch string
+	reviewID      string
+	threadID      string
+	repoPath      string
+	requester     int64
+	branch        string
+	baseBranch    string
 	commitSHA     string
 	securityDepth string
 	config        *ReviewerConfig

--- a/web/frontend/src/components/inbox/ComposeModal.tsx
+++ b/web/frontend/src/components/inbox/ComposeModal.tsx
@@ -98,10 +98,11 @@ export function ComposeModal({
     );
   }, [form, initialValues]);
 
-  // Reset form when modal opens.
+  // Reset form and UI state when modal opens or closes.
   const handleReset = useCallback(() => {
     setForm({ ...initialFormState, ...initialValues });
     setErrors({});
+    setIsExpanded(false);
   }, [initialValues]);
 
   // Handle field change.
@@ -220,6 +221,7 @@ export function ComposeModal({
         onSubmit={(e) => void handleSubmit(e)}
         className={
           isExpanded
+            // 10rem accounts for: modal padding (2rem) + header (4rem) + footer (4rem).
             ? 'flex flex-col gap-4 h-[calc(100vh-10rem)]'
             : 'space-y-4'
         }

--- a/web/frontend/src/components/inbox/ComposeModal.tsx
+++ b/web/frontend/src/components/inbox/ComposeModal.tsx
@@ -80,6 +80,9 @@ export function ComposeModal({
     ...initialValues,
   }));
 
+  // Whether the modal is expanded to fullscreen.
+  const [isExpanded, setIsExpanded] = useState(false);
+
   // Validation errors.
   const [errors, setErrors] = useState<Partial<Record<keyof ComposeFormState, string>>>({});
 
@@ -177,9 +180,50 @@ export function ComposeModal({
     onClose();
   }, [isDirty, handleReset, onClose]);
 
+  // Expand/collapse toggle button rendered in the modal header.
+  const expandButton = (
+    <button
+      type="button"
+      className="rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+      onClick={() => setIsExpanded((prev) => !prev)}
+      aria-label={isExpanded ? 'Exit fullscreen' : 'Fullscreen'}
+      title={isExpanded ? 'Exit fullscreen' : 'Fullscreen'}
+    >
+      {isExpanded ? (
+        // Collapse icon (arrows pointing inward).
+        <svg className="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 9L4 4m0 0v4m0-4h4m6 6l5 5m0 0v-4m0 4h-4M9 15l-5 5m0 0v-4m0 4h4m6-6l5-5m0 0v4m0-4h-4" />
+        </svg>
+      ) : (
+        // Expand icon (arrows pointing outward).
+        <svg className="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 8V4m0 0h4M4 4l5 5m11-5h-4m4 0v4m0-4l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5h-4m4 0v-4m0 4l-5-5" />
+        </svg>
+      )}
+    </button>
+  );
+
   return (
-    <Modal isOpen={isOpen} onClose={handleClose} size="3xl" title={title}>
-      <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      size={isExpanded ? 'full' : '3xl'}
+      title={title}
+      headerActions={expandButton}
+      resizable={!isExpanded}
+      className={isExpanded
+        ? 'max-w-[calc(100vw-2rem)] !w-[calc(100vw-2rem)] h-[calc(100vh-2rem)]'
+        : undefined
+      }
+    >
+      <form
+        onSubmit={(e) => void handleSubmit(e)}
+        className={
+          isExpanded
+            ? 'flex flex-col gap-4 h-[calc(100vh-10rem)]'
+            : 'space-y-4'
+        }
+      >
         {/* Recipients. */}
         <RecipientInput
           label="To"
@@ -201,16 +245,25 @@ export function ComposeModal({
           error={errors.subject}
         />
 
-        {/* Body. */}
-        <Textarea
-          label="Message"
-          value={form.body}
-          onChange={(e) => handleChange('body', e.target.value)}
-          placeholder="Write your message... (Markdown supported)"
-          rows={12}
-          disabled={isSending}
-          error={errors.body}
-        />
+        {/* Body - grows to fill available space when expanded. */}
+        <div
+          className={
+            isExpanded
+              ? 'flex-1 flex flex-col min-h-0 [&_div.w-full]:flex-1 [&_div.w-full]:flex [&_div.w-full]:flex-col [&_textarea]:flex-1'
+              : ''
+          }
+        >
+          <Textarea
+            label="Message"
+            value={form.body}
+            onChange={(e) => handleChange('body', e.target.value)}
+            placeholder="Write your message... (Markdown supported)"
+            rows={isExpanded ? undefined : 12}
+            disabled={isSending}
+            error={errors.body}
+            className={isExpanded ? 'resize-none' : ''}
+          />
+        </div>
 
         {/* Priority and Deadline row. */}
         <div className="grid grid-cols-2 gap-4">

--- a/web/frontend/src/components/inbox/ThreadMessage.tsx
+++ b/web/frontend/src/components/inbox/ThreadMessage.tsx
@@ -27,12 +27,6 @@ function getSenderAsAgent(message: Message) {
   };
 }
 
-// Configure marked options for safe rendering.
-marked.setOptions({
-  gfm: true,
-  breaks: true,
-});
-
 // Combine clsx and tailwind-merge for class name handling.
 function cn(...inputs: (string | undefined | null | false)[]) {
   return twMerge(clsx(inputs));
@@ -99,6 +93,8 @@ function renderMarkdownToHtml(text: string): string {
       'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'a', 'blockquote', 'hr',
       'table', 'thead', 'tbody', 'tr', 'th', 'td',
     ],
+    // Note: style intentionally excluded to prevent CSS injection.
+    // GFM column alignment (:---:) is lost as a security trade-off.
     ALLOWED_ATTR: ['href', 'target', 'rel'],
   });
 }

--- a/web/frontend/src/components/inbox/ThreadMessage.tsx
+++ b/web/frontend/src/components/inbox/ThreadMessage.tsx
@@ -89,12 +89,15 @@ function splitBodyAndDiff(body: string): { text: string; patch: string | null } 
 // Render markdown text safely using marked and DOMPurify.
 function renderMarkdownToHtml(text: string): string {
   // Parse markdown to HTML.
-  const rawHtml = marked.parse(text, { async: false }) as string;
+  const rawHtml = marked.parse(text, {
+    async: false, gfm: true, breaks: true,
+  }) as string;
   // Sanitize HTML to prevent XSS.
   return DOMPurify.sanitize(rawHtml, {
     ALLOWED_TAGS: [
       'p', 'br', 'strong', 'em', 'code', 'pre', 'ul', 'ol', 'li',
       'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'a', 'blockquote', 'hr',
+      'table', 'thead', 'tbody', 'tr', 'th', 'td',
     ],
     ALLOWED_ATTR: ['href', 'target', 'rel'],
   });

--- a/web/frontend/src/components/inbox/ThreadView.tsx
+++ b/web/frontend/src/components/inbox/ThreadView.tsx
@@ -262,6 +262,9 @@ export function ThreadView({
   const [isReplying, setIsReplying] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
 
+  // State for fullscreen modal.
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
   // State for focused message index.
   const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
 
@@ -347,9 +350,15 @@ export function ThreadView({
     <Modal
       isOpen={isOpen}
       onClose={onClose}
-      size="3xl"
-      className="flex h-[80vh] flex-col overflow-hidden"
+      size={isFullscreen ? 'full' : '3xl'}
+      className={cn(
+        'flex flex-col overflow-hidden',
+        isFullscreen
+          ? 'max-w-[calc(100vw-2rem)] !w-[calc(100vw-2rem)] h-[calc(100vh-2rem)]'
+          : 'h-[80vh]',
+      )}
       rawContent
+      resizable={!isFullscreen}
       showCloseButton={false}
     >
       {/* Toolbar. */}
@@ -413,6 +422,11 @@ export function ThreadView({
             disabled={!hasNext || isActionLoading}
           />
           <div className="ml-2 h-5 w-px bg-gray-300" />
+          <ToolbarButton
+            onClick={() => setIsFullscreen(!isFullscreen)}
+            icon={isFullscreen ? <CollapseIcon /> : <ExpandIcon />}
+            label={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+          />
           <button
             type="button"
             onClick={onClose}

--- a/web/frontend/src/components/inbox/ThreadView.tsx
+++ b/web/frontend/src/components/inbox/ThreadView.tsx
@@ -262,8 +262,11 @@ export function ThreadView({
   const [isReplying, setIsReplying] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
 
-  // State for fullscreen modal.
+  // State for fullscreen modal, reset when the modal closes.
   const [isFullscreen, setIsFullscreen] = useState(false);
+  useEffect(() => {
+    if (!isOpen) setIsFullscreen(false);
+  }, [isOpen]);
 
   // State for focused message index.
   const [focusedIndex, setFocusedIndex] = useState<number | null>(null);

--- a/web/frontend/src/components/plans/PlanDetailView.tsx
+++ b/web/frontend/src/components/plans/PlanDetailView.tsx
@@ -24,7 +24,9 @@ function formatTimestamp(ts: number): string {
 
 // Render markdown safely using marked and DOMPurify.
 function renderMarkdown(text: string): string {
-  const rawHtml = marked.parse(text, { async: false }) as string;
+  const rawHtml = marked.parse(text, {
+    async: false, gfm: true, breaks: true,
+  }) as string;
   return DOMPurify.sanitize(rawHtml, {
     ALLOWED_TAGS: [
       'p', 'br', 'strong', 'em', 'code', 'pre', 'ul', 'ol', 'li',

--- a/web/frontend/src/components/reviews/ReviewDetailView.tsx
+++ b/web/frontend/src/components/reviews/ReviewDetailView.tsx
@@ -305,11 +305,14 @@ export function ReviewDetailView({ review }: ReviewDetailViewProps) {
 
 // Render markdown safely using marked and DOMPurify.
 function renderMarkdown(text: string): string {
-  const rawHtml = marked.parse(text, { async: false }) as string;
+  const rawHtml = marked.parse(text, {
+    async: false, gfm: true, breaks: true,
+  }) as string;
   return DOMPurify.sanitize(rawHtml, {
     ALLOWED_TAGS: [
       'p', 'br', 'strong', 'em', 'code', 'pre', 'ul', 'ol', 'li',
       'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'a', 'blockquote', 'hr',
+      'table', 'thead', 'tbody', 'tr', 'th', 'td',
     ],
     ALLOWED_ATTR: ['href', 'target', 'rel'],
   });

--- a/web/frontend/src/components/ui/Modal.tsx
+++ b/web/frontend/src/components/ui/Modal.tsx
@@ -146,7 +146,7 @@ export function Modal({
                 {...(resizable ? { style: { width: resizableInitialWidths[size] } } : {})}
               >
                 {/* Header - only show if not using rawContent mode. */}
-                {!rawContent && (title || showCloseButton) ? (
+                {!rawContent && (title || showCloseButton || headerActions) ? (
                   <div className="flex items-start justify-between border-b border-gray-200 px-6 py-4">
                     <div>
                       {title ? (

--- a/web/frontend/src/components/ui/Modal.tsx
+++ b/web/frontend/src/components/ui/Modal.tsx
@@ -37,7 +37,7 @@ export interface ModalProps {
   resizable?: boolean | undefined;
 }
 
-// Size styles mapping.
+// Size styles mapping for non-resizable modals.
 const sizeStyles: Record<ModalSize, string> = {
   sm: 'max-w-sm',
   md: 'max-w-md',
@@ -46,6 +46,17 @@ const sizeStyles: Record<ModalSize, string> = {
   '2xl': 'max-w-2xl',
   '3xl': 'max-w-3xl',
   full: 'max-w-4xl',
+};
+
+// Initial widths (px) for resizable modals so they start at a reasonable size.
+const resizableInitialWidths: Record<ModalSize, number> = {
+  sm: 384,
+  md: 448,
+  lg: 512,
+  xl: 576,
+  '2xl': 672,
+  '3xl': 768,
+  full: 896,
 };
 
 // Close button icon.
@@ -125,12 +136,14 @@ export function Modal({
             >
               <DialogPanel
                 className={cn(
-                  'w-full transform rounded-lg bg-white shadow-xl transition-all',
-                  !rawContent && 'overflow-hidden',
-                  resizable && 'resize overflow-auto min-w-[320px] min-h-[200px]',
-                  sizeStyles[size],
+                  'transform rounded-lg bg-white shadow-xl transition-all',
+                  !resizable && 'w-full',
+                  !rawContent && !resizable && 'overflow-hidden',
+                  resizable && 'resize overflow-auto min-w-[320px] min-h-[200px] max-w-[calc(100vw-2rem)] max-h-[calc(100vh-2rem)]',
+                  !resizable && sizeStyles[size],
                   className,
                 )}
+                {...(resizable ? { style: { width: resizableInitialWidths[size] } } : {})}
               >
                 {/* Header - only show if not using rawContent mode. */}
                 {!rawContent && (title || showCloseButton) ? (

--- a/web/frontend/src/components/ui/Modal.tsx
+++ b/web/frontend/src/components/ui/Modal.tsx
@@ -31,6 +31,10 @@ export interface ModalProps {
   initialFocus?: React.RefObject<HTMLElement | null> | undefined;
   /** When true, content is rendered directly without padding wrapper. */
   rawContent?: boolean | undefined;
+  /** Extra action buttons rendered in the header, before the close button. */
+  headerActions?: ReactNode | undefined;
+  /** When true, the modal can be resized by dragging its edges. */
+  resizable?: boolean | undefined;
 }
 
 // Size styles mapping.
@@ -77,6 +81,8 @@ export function Modal({
   className,
   initialFocus,
   rawContent = false,
+  headerActions,
+  resizable = false,
 }: ModalProps) {
   const handleClose = () => {
     if (closeOnOverlayClick) {
@@ -121,6 +127,7 @@ export function Modal({
                 className={cn(
                   'w-full transform rounded-lg bg-white shadow-xl transition-all',
                   !rawContent && 'overflow-hidden',
+                  resizable && 'resize overflow-auto min-w-[320px] min-h-[200px]',
                   sizeStyles[size],
                   className,
                 )}
@@ -141,16 +148,19 @@ export function Modal({
                         <p className="mt-1 text-sm text-gray-500">{description}</p>
                       ) : null}
                     </div>
-                    {showCloseButton ? (
-                      <button
-                        type="button"
-                        className="ml-4 rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-                        onClick={onClose}
-                        aria-label="Close modal"
-                      >
-                        <CloseIcon />
-                      </button>
-                    ) : null}
+                    <div className="ml-4 flex items-center gap-1">
+                      {headerActions}
+                      {showCloseButton ? (
+                        <button
+                          type="button"
+                          className="rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                          onClick={onClose}
+                          aria-label="Close modal"
+                        >
+                          <CloseIcon />
+                        </button>
+                      ) : null}
+                    </div>
                   </div>
                 ) : null}
 

--- a/web/frontend/src/index.css
+++ b/web/frontend/src/index.css
@@ -297,6 +297,38 @@
     margin: 1.5em 0;
   }
 
+  .prose table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1em 0;
+    font-size: 0.875em;
+  }
+
+  .prose thead {
+    border-bottom: 2px solid var(--color-gray-300);
+  }
+
+  .prose th {
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+    font-weight: 600;
+    color: var(--color-gray-900);
+    background-color: var(--color-gray-50);
+  }
+
+  .prose td {
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid var(--color-gray-200);
+  }
+
+  .prose tbody tr:last-child td {
+    border-bottom: none;
+  }
+
+  .prose tbody tr:hover {
+    background-color: var(--color-gray-50);
+  }
+
   .prose-sm {
     font-size: 0.875rem;
   }

--- a/web/frontend/tests/integration/components/Modal.test.tsx
+++ b/web/frontend/tests/integration/components/Modal.test.tsx
@@ -212,6 +212,87 @@ describe('Modal', () => {
     });
   });
 
+  describe('headerActions', () => {
+    it('renders headerActions in the header', async () => {
+      render(
+        <Modal isOpen onClose={() => {}} title="Title" headerActions={
+          <button aria-label="Fullscreen">Expand</button>
+        }>
+          <div>Content</div>
+        </Modal>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Fullscreen')).toBeInTheDocument();
+        expect(screen.getByText('Expand')).toBeInTheDocument();
+      });
+    });
+
+    it('renders headerActions next to close button', async () => {
+      render(
+        <Modal isOpen onClose={() => {}} title="Title" headerActions={
+          <button aria-label="Fullscreen">Expand</button>
+        }>
+          <div>Content</div>
+        </Modal>,
+      );
+
+      await waitFor(() => {
+        const expandBtn = screen.getByLabelText('Fullscreen');
+        const closeBtn = screen.getByLabelText('Close modal');
+        // Both should share the same parent container.
+        expect(expandBtn.parentElement).toBe(closeBtn.parentElement);
+      });
+    });
+
+    it('does not render headerActions wrapper when not provided', async () => {
+      render(
+        <Modal isOpen onClose={() => {}} title="Title">
+          <div>Content</div>
+        </Modal>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Close modal')).toBeInTheDocument();
+      });
+      // The close button should still render normally.
+      expect(screen.queryByLabelText('Fullscreen')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('resizable', () => {
+    it('applies resize class when resizable is true', async () => {
+      render(
+        <Modal isOpen onClose={() => {}} resizable>
+          <div>Content</div>
+        </Modal>,
+      );
+
+      await waitFor(() => {
+        const panel = screen.getByText('Content').closest('[class*="resize"]');
+        expect(panel).toBeInTheDocument();
+        expect(panel?.className).toContain('resize');
+      });
+    });
+
+    it('does not apply resize class by default', async () => {
+      render(
+        <Modal isOpen onClose={() => {}}>
+          <div>Content</div>
+        </Modal>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Content')).toBeInTheDocument();
+      });
+
+      const panel = screen.getByText('Content').closest('[role="dialog"]');
+      // The dialog panel should not have resize class.
+      const dialogPanel = panel?.querySelector('[class*="transform"]');
+      expect(dialogPanel?.className).not.toContain('resize');
+    });
+  });
+
   describe('custom className', () => {
     it('applies custom className to modal panel', async () => {
       render(

--- a/web/frontend/tests/integration/components/Modal.test.tsx
+++ b/web/frontend/tests/integration/components/Modal.test.tsx
@@ -275,6 +275,36 @@ describe('Modal', () => {
       });
     });
 
+    it('sets inline width style for initial size when resizable', async () => {
+      render(
+        <Modal isOpen onClose={() => {}} resizable size="3xl">
+          <div>Content</div>
+        </Modal>,
+      );
+
+      await waitFor(() => {
+        const panel = screen.getByText('Content').closest('[class*="resize"]');
+        expect(panel).toBeInTheDocument();
+        // Should have an inline width style (768px for 3xl).
+        expect((panel as HTMLElement)?.style.width).toBe('768px');
+      });
+    });
+
+    it('does not set inline width when not resizable', async () => {
+      render(
+        <Modal isOpen onClose={() => {}} size="3xl">
+          <div>Content</div>
+        </Modal>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Content')).toBeInTheDocument();
+      });
+
+      const panel = screen.getByText('Content').closest('[class*="max-w"]');
+      expect((panel as HTMLElement)?.style.width).toBe('');
+    });
+
     it('does not apply resize class by default', async () => {
       render(
         <Modal isOpen onClose={() => {}}>

--- a/web/frontend/tests/integration/components/inbox/ComposeModal.test.tsx
+++ b/web/frontend/tests/integration/components/inbox/ComposeModal.test.tsx
@@ -343,6 +343,40 @@ describe('ComposeModal', () => {
     window.confirm = originalConfirm;
   });
 
+  it('renders fullscreen toggle button', () => {
+    render(<ComposeModal {...defaultProps} />);
+
+    expect(screen.getByLabelText('Fullscreen')).toBeInTheDocument();
+  });
+
+  it('toggles fullscreen mode when expand button is clicked', async () => {
+    const user = userEvent.setup();
+
+    render(<ComposeModal {...defaultProps} />);
+
+    const expandBtn = screen.getByLabelText('Fullscreen');
+    await user.click(expandBtn);
+
+    // After clicking, the button label should change to exit fullscreen.
+    expect(screen.getByLabelText('Exit fullscreen')).toBeInTheDocument();
+  });
+
+  it('toggles back to normal mode on second click', async () => {
+    const user = userEvent.setup();
+
+    render(<ComposeModal {...defaultProps} />);
+
+    const expandBtn = screen.getByLabelText('Fullscreen');
+    await user.click(expandBtn);
+
+    // Now in fullscreen, click again to collapse.
+    const collapseBtn = screen.getByLabelText('Exit fullscreen');
+    await user.click(collapseBtn);
+
+    // Should be back to normal mode.
+    expect(screen.getByLabelText('Fullscreen')).toBeInTheDocument();
+  });
+
   it('accepts custom title', () => {
     render(<ComposeModal {...defaultProps} title="Reply to Thread" />);
 

--- a/web/frontend/tests/integration/components/inbox/ThreadView.test.tsx
+++ b/web/frontend/tests/integration/components/inbox/ThreadView.test.tsx
@@ -84,6 +84,34 @@ describe('ThreadMessage', () => {
     expect(article).toHaveClass('border-blue-300');
   });
 
+  it('renders markdown tables in message body', () => {
+    const tableMessage: Message = {
+      ...mockMessages[0],
+      body: '| Name | Value |\n|------|-------|\n| Alpha | 100 |\n| Beta | 200 |',
+    };
+
+    render(<ThreadMessage message={tableMessage} />);
+
+    // Table elements should be rendered, not stripped.
+    const article = document.querySelector('[role="article"]');
+    expect(article?.querySelector('table')).toBeInTheDocument();
+    expect(article?.querySelector('th')).toBeInTheDocument();
+    expect(article?.querySelector('td')).toBeInTheDocument();
+  });
+
+  it('renders single newlines as line breaks', () => {
+    const newlineMessage: Message = {
+      ...mockMessages[0],
+      body: 'Line one\nLine two\nLine three',
+    };
+
+    render(<ThreadMessage message={newlineMessage} />);
+
+    const article = document.querySelector('[role="article"]');
+    const brs = article?.querySelectorAll('br');
+    expect(brs?.length).toBeGreaterThanOrEqual(2);
+  });
+
   it('renders priority badge for non-normal priority', () => {
     const urgentMessage: Message = {
       ...mockMessages[0],
@@ -331,6 +359,34 @@ describe('ThreadView', () => {
     // Focus should move (we check by class change - focused message has blue border).
     // Since this is internal state, just verify no errors occur.
     expect(container).toBeInTheDocument();
+  });
+
+  it('renders fullscreen toggle button in toolbar', () => {
+    render(<ThreadView {...defaultProps} thread={mockThread} />);
+
+    expect(screen.getByLabelText('Fullscreen')).toBeInTheDocument();
+  });
+
+  it('toggles fullscreen mode when expand button is clicked', async () => {
+    const user = userEvent.setup();
+
+    render(<ThreadView {...defaultProps} thread={mockThread} />);
+
+    await user.click(screen.getByLabelText('Fullscreen'));
+
+    // After clicking, label should change to exit fullscreen.
+    expect(screen.getByLabelText('Exit fullscreen')).toBeInTheDocument();
+  });
+
+  it('toggles back from fullscreen on second click', async () => {
+    const user = userEvent.setup();
+
+    render(<ThreadView {...defaultProps} thread={mockThread} />);
+
+    await user.click(screen.getByLabelText('Fullscreen'));
+    await user.click(screen.getByLabelText('Exit fullscreen'));
+
+    expect(screen.getByLabelText('Fullscreen')).toBeInTheDocument();
   });
 
   it('closes on Escape key', () => {


### PR DESCRIPTION
## Summary
- Add fullscreen toggle button to ComposeModal and ThreadView modals
- Add drag-to-resize capability (horizontal, vertical, diagonal) via CSS `resize: both`
- Fix markdown rendering: single newlines now render as `<br>`, tables no longer stripped by DOMPurify
- Add prose table CSS styles (borders, padding, header background, hover highlights)
- Add `headerActions` and `resizable` props to the base Modal component

## Test plan
- [x] All 1458 frontend tests pass across 68 test files
- [x] New tests for Modal headerActions, resizable prop, inline width behavior
- [x] New tests for ThreadView fullscreen toggle, markdown tables, line breaks
- [x] New tests for ComposeModal fullscreen toggle
- [x] Verified in browser: both modals resize in all directions
- [x] TypeScript type check passes